### PR TITLE
新增文章列表顯示功能及分頁導航，並更新資料庫

### DIFF
--- a/frontend/src/pages/ArticlesPage.js
+++ b/frontend/src/pages/ArticlesPage.js
@@ -1,31 +1,57 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import '../styles/pages/LoginPage.css'
+import '../styles/pages/ArticlesPage.css';
 
 const ArticlesPage = () => {
+  const [articles, setArticles] = useState([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  useEffect(() => {
+    fetch(`http://localhost:8080/blog/api/articles?page=${currentPage}&size=10`)
+      .then(response => response.json())
+      .then(data => {
+        setArticles(data.content);
+        setTotalPages(data.totalPages);
+      });
+  }, [currentPage]);
+  
+
+  const handlePageChange = (page) => {
+    if (page >= 0 && page < totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
   return (
     <main className="content">
       <section className="article-list">
         <div className="post-container">
-          <article className="post">
-            <Link to="/single-article">奧運射擊比賽亞軍是土耳其殺手?! | 作者 : abc | 更新於 : 2024/08/02</Link>
-          </article>
-          <article className="post">
-            <Link to="/single-article">奧運射擊比賽亞軍是土耳其殺手?! | 作者 : abc | 更新於 : 2024/08/02</Link>
-          </article>
-          {/* 可以繼續添加更多文章 */}
+          {articles.map(article => (
+            <article className="post" key={article.id}>
+              <Link to={`/single-article/${article.id}`}>
+                {article.title} | 作者 : {article.author} | 更新於 : {new Date(article.updatedDate).toLocaleDateString()}
+              </Link>
+            </article>
+          ))}
         </div>
 
         {/* 分頁導航 */}
         <nav className="pagination">
-          <Link to="#">首頁</Link>
-          <Link to="#">1</Link>
-          <Link to="#">2</Link>
-          <Link to="#">3</Link>
-          <Link to="#">4</Link>
-          <Link to="#">5</Link>
-          <Link to="#">尾頁</Link>
+          <Link to="#" onClick={() => handlePageChange(0)} className={currentPage === 0 ? 'active' : ''}>首頁</Link>
+          {Array.from({ length: totalPages }).map((_, index) => (
+            <Link
+              key={index}
+              to="#"
+              onClick={() => handlePageChange(index)}
+              className={index === currentPage ? 'active' : ''}
+            >
+              {index + 1}
+            </Link>
+          ))}
+          <Link to="#" onClick={() => handlePageChange(totalPages - 1)} className={currentPage === totalPages - 1 ? 'active' : ''}>尾頁</Link>
         </nav>
+
       </section>
 
       {/* 置頂按鈕 */}

--- a/src/main/java/com/example/blog/ArticleRepository.java
+++ b/src/main/java/com/example/blog/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.example.blog;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Articles, Long> {
+}
+

--- a/src/main/java/com/example/blog/Articles.java
+++ b/src/main/java/com/example/blog/Articles.java
@@ -1,0 +1,63 @@
+package com.example.blog;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Date;
+
+@Entity
+@Table(name = "articles")
+public class Articles {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String author;
+    private Date updatedDate;
+    private String content; // 新增文章內容欄位
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public Date getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public void setUpdatedDate(Date updatedDate) {
+        this.updatedDate = updatedDate;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/blog/ArticlesController.java
+++ b/src/main/java/com/example/blog/ArticlesController.java
@@ -1,0 +1,30 @@
+package com.example.blog;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/articles")
+public class ArticlesController {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @GetMapping
+    public Page<Articles> getArticles(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "updatedDate") String sortBy) {
+        
+        // 使用 Sort 進行排序
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortBy).descending());
+        return articleRepository.findAll(pageable);
+    }
+}


### PR DESCRIPTION
- 新增文章和標籤實體類。
- 實作處理文章列表顯示的控制器。
- 創建文章和標籤的 repository 類以進行資料庫操作。
- 為文章列表頁面新增 JavaScript 檔案，實現分頁和導航功能。
- 建立新的資料庫表格：文章和標籤。
- 向文章和標籤表格插入了樣本數據。

這次更新包含了完整的文章列表顯示及分頁功能，並完成了相關的後端和資料庫更改。