### PR TITLE
實現透過點擊標籤列顯示標籤文章功能和在文章顯示標籤

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import EmailVerificationPage from './pages/EmailVerificationPage';
 import ChangePassword from './pages/ChangePassword';
+import TagPage from './pages/TagPage';
 
 const MainLayout = ({ children }) => (
   <main className={style.App}>
@@ -42,6 +43,7 @@ const App = () => {
           <Route path="/UserData" element={<MainLayout><UserData /></MainLayout>} />
           <Route path="/edit-article/:articleId" element={<MainLayout><ArticleEditor /></MainLayout>} />
           <Route path="/verify-email" element={<MainLayout><EmailVerificationPage /></MainLayout>} />
+          <Route path="/tag/:tagId" element={<MainLayout><TagPage /></MainLayout>} />
           {/* 你可以在这里添加更多的路由 */}
         </Routes>
       <Footer />

--- a/frontend/src/components/SearchBar.js
+++ b/frontend/src/components/SearchBar.js
@@ -1,11 +1,16 @@
 // src/components/SearchBar.js
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../styles/components/SearchBar.module.css'; // 引入 CSS 模組
 
-function SearchBar() {
-  const [query, setQuery] = useState(''); // 用來儲存使用者輸入的搜尋詞
+function SearchBar({ value }) {
+  const [query, setQuery] = useState(value || ''); // 用來儲存使用者輸入的搜尋詞
   const navigate = useNavigate();
+
+  // 在 value 更新時，更新 query
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
 
   // 處理搜尋提交
   const handleSearch = (e) => {

--- a/frontend/src/pages/ArticlesPage.js
+++ b/frontend/src/pages/ArticlesPage.js
@@ -74,7 +74,7 @@ function ArticlesPage() {
         <button onClick={handlePreviousPage} disabled={currentPage === 0}>
           上一頁
         </button>
-        <span>頁 {currentPage + 1} / {totalPages}</span>
+        <span> {currentPage + 1} / {totalPages}頁 </span>
         <button onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
           下一頁
         </button>

--- a/frontend/src/pages/ArticlesPage.js
+++ b/frontend/src/pages/ArticlesPage.js
@@ -1,4 +1,5 @@
 // src/pages/ArticlesPage.js
+
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
@@ -7,6 +8,7 @@ import styles from '../styles/pages/ArticlesPage.module.css'; // 引入 CSS 模�
 
 function ArticlesPage() {
   const [articles, setArticles] = useState([]);
+  const [tags, setTags] = useState([]);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const navigate = useNavigate();
@@ -30,7 +32,18 @@ function ArticlesPage() {
       }
     };
 
+    const fetchTags = async () => {
+      try {
+        const response = await axios.get('http://localhost:8080/blog/api/tags/all');
+        const sortedTags = response.data.sort((a, b) => a.tag_id - b.tag_id);
+        setTags(sortedTags);
+      } catch (error) {
+        console.error('獲取標籤失敗:', error);
+      }
+    };
+
     fetchArticles();
+    fetchTags();
   }, [currentPage]);
 
   const handleSearch = (query) => {
@@ -49,9 +62,31 @@ function ArticlesPage() {
     }
   };
 
+  const handleTagClick = (tagId) => {
+    navigate(`/tag/${tagId}`); // 導航到標籤頁面
+  };
+
+  const getTagNameById = (id) => {
+    const tag = tags.find(tag => tag.tag_id === id);
+    return tag ? tag.name : '未知標籤';
+  };
+
   return (
     <div className={styles.articles_page}>
       <SearchBar onSearch={handleSearch} />
+      
+      <div className={styles['tag-list']}>
+        {tags.map(tag => (
+          <button
+            key={tag.tag_id}
+            className={styles['tag-item']}
+            onClick={() => handleTagClick(tag.tag_id)}
+          >
+            {tag.name}
+          </button>
+        ))}
+      </div>
+
       <div className={styles['article-list']}>
         {articles.length > 0 ? (
           articles.map((article) => (
@@ -60,6 +95,7 @@ function ArticlesPage() {
                 <a href={`/singleArticle/${article.article_id}`} className={styles['article-title']}>{article.title}</a>
                 <span className={styles['article-author']}>| 作者: {article.username || '未知作者'}</span>
                 <span className={styles['article-updated']}>| 更新時間: {article.last_edited_at}</span>
+                <span className={styles['article-tag']}>| {getTagNameById(article.tag_id)}</span>
               </div>
               <div className={styles['article-excerpt']}>
                 {article.contentTEXT}
@@ -70,6 +106,7 @@ function ArticlesPage() {
           <p>沒有找到文章</p>
         )}
       </div>
+
       <div className={styles.pagination}>
         <button onClick={handlePreviousPage} disabled={currentPage === 0}>
           上一頁
@@ -84,5 +121,3 @@ function ArticlesPage() {
 }
 
 export default ArticlesPage;
-
-

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -74,7 +74,7 @@ function SearchPage() {
         <button onClick={handlePreviousPage} disabled={currentPage === 0}>
           上一頁
         </button>
-        <span>頁 {currentPage + 1} / {totalPages}</span>
+        <span> {currentPage + 1} / {totalPages}頁 </span>
         <button onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
           下一頁
         </button>

--- a/frontend/src/pages/TagPage.js
+++ b/frontend/src/pages/TagPage.js
@@ -1,0 +1,117 @@
+// src/pages/TagPage.js
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import SearchBar from '../components/SearchBar';
+import styles from '../styles/pages/TagPage.module.css';
+
+function TagPage() {
+  const { tagId } = useParams();
+  const [articles, setArticles] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search).get('query') || ''; // 取得搜尋參數
+
+  useEffect(() => {
+    const fetchArticles = async () => {
+      try {
+        const response = await axios.get('http://localhost:8080/blog/articlesByTag', {
+          params: { tagId, page: currentPage, size: 10 }
+        });
+        setArticles(response.data.content);
+        setTotalPages(response.data.totalPages);
+      } catch (error) {
+        console.error('獲取標籤文章失敗:', error);
+      }
+    };
+
+    const fetchTags = async () => {
+      try {
+        const response = await axios.get('http://localhost:8080/blog/api/tags/all');
+        const sortedTags = response.data.sort((a, b) => a.tag_id - b.tag_id);
+        setTags(sortedTags);
+      } catch (error) {
+        console.error('獲取標籤失敗:', error);
+      }
+    };
+
+    fetchArticles();
+    fetchTags();
+  }, [tagId, currentPage]);
+
+  const handlePreviousPage = () => {
+    if (currentPage > 0) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages - 1) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  const handleTagClick = (id) => {
+    navigate(`/tag/${id}?query=${encodeURIComponent(query)}`); // 保留搜尋參數
+  };
+
+  const getTagNameById = (id) => {
+    const tag = tags.find(tag => tag.tag_id === id);
+    return tag ? tag.name : '未知標籤';
+  };
+
+  const handleSearch = (query) => {
+    navigate(`/searchPage?query=${encodeURIComponent(query)}`);
+  };
+
+  return (
+    <div className={styles.tag_page}>
+      <SearchBar onSearch={handleSearch} value={query} /> {/* 傳遞搜尋參數 */}
+      
+      <div className={styles.tag_list}>
+        {tags.map((tag) => (
+          <button
+            key={tag.tag_id}
+            onClick={() => handleTagClick(tag.tag_id)}
+            className={styles.tag_button}
+          >
+            {tag.name}
+          </button>
+        ))}
+      </div>
+      <div className={styles['article-list']}>
+        {articles.length > 0 ? (
+          articles.map((article) => (
+            <div key={article.article_id} className={styles['article-card']}>
+              <div className={styles['article-content']}>
+                <a href={`/singleArticle/${article.article_id}`} className={styles['article-title']}>{article.title}</a>
+                <span className={styles['article-author']}>| 作者: {article.username || '未知作者'}</span>
+                <span className={styles['article-updated']}>| 更新時間: {article.last_edited_at}</span>
+                <span className={styles['article-tag']}>| {getTagNameById(article.tag_id)}</span>
+              </div>
+              <div className={styles['article-excerpt']}>
+                {article.contentTEXT}
+              </div>
+            </div>
+          ))
+        ) : (
+          <p>沒有找到文章</p>
+        )}
+      </div>
+      <div className={styles.pagination}>
+        <button onClick={handlePreviousPage} disabled={currentPage === 0}>
+          上一頁
+        </button>
+        <span> {currentPage + 1} / {totalPages}頁 </span>
+        <button onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
+          下一頁
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default TagPage;

--- a/frontend/src/styles/pages/ArticlesPage.module.css
+++ b/frontend/src/styles/pages/ArticlesPage.module.css
@@ -17,6 +17,30 @@
   justify-content: center;
 }
 
+/* 標籤列表區域 */
+.tag-list {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px; /* 標籤之間的間距 */
+}
+
+/* 標籤項目樣式 */
+.tag-item {
+  background-color: #ffffff; /* 項目背景顏色 */
+  border: 1px solid #ddd; /* 項目邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.tag-item:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
+}
+
 /* 文章列表區域 */
 .article-list {
   width: 80%; /* 調整寬度 */
@@ -54,16 +78,17 @@
   margin-right: 10px;
   color: #333; /* 標題顏色 */
   flex: 1; /* 使標題占據可用空間 */
-  white-space: nowrap;        /* 不換行 */
-  overflow: hidden;           /* 隱藏超出容器的內容 */
-  text-overflow: ellipsis;    /* 使用省略號表示被截斷的文字 */
-  font-size: 1.3rem;         /* 調整字體大小，可以根據需要修改 */
+  white-space: nowrap; /* 不換行 */
+  overflow: hidden; /* 隱藏超出容器的內容 */
+  text-overflow: ellipsis; /* 使用省略號表示被截斷的文字 */
+  font-size: 1.3rem; /* 調整字體大小，可以根據需要修改 */
 }
 
 .article-author,
-.article-updated {
+.article-updated,
+.article-tag {
   margin-right: 10px;
-  color: #333; /* 作者和更新時間顏色 */
+  color: #333; /* 作者、更新時間和標籤顏色 */
 }
 
 /* 文章摘要 */
@@ -75,4 +100,32 @@
   text-overflow: ellipsis;
   -webkit-line-clamp: 2; /* 顯示兩行 */
   line-height: 1.5; /* 行高，可根據需要調整 */
+}
+
+/* 分頁樣式 */
+.pagination {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination button {
+  background-color: #ffffff; /* 按鈕背景顏色 */
+  border: 1px solid #ddd; /* 按鈕邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+  margin: 0 10px;
+}
+
+.pagination button:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
+}
+
+.pagination span {
+  font-size: 1rem;
 }

--- a/frontend/src/styles/pages/SearchPage.module.css
+++ b/frontend/src/styles/pages/SearchPage.module.css
@@ -17,6 +17,30 @@
   justify-content: center;
 }
 
+/* 標籤列表區域 */
+.tag_list {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px; /* 標籤之間的間距 */
+}
+
+/* 標籤按鈕樣式 */
+.tag_button {
+  background-color: #ffffff; /* 按鈕背景顏色 */
+  border: 1px solid #ddd; /* 按鈕邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.tag_button:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
+}
+
 /* 搜尋結果列表區域 */
 .results-list {
   width: 80%; /* 調整寬度 */
@@ -54,10 +78,10 @@
   margin-right: 10px;
   color: #333; /* 標題顏色 */
   flex: 1; /* 使標題占據可用空間 */
-  white-space: nowrap;        /* 不換行 */
-  overflow: hidden;           /* 隱藏超出容器的內容 */
-  text-overflow: ellipsis;    /* 使用省略號表示被截斷的文字 */
-  font-size: 1.3rem;         /* 調整字體大小 */
+  white-space: nowrap; /* 不換行 */
+  overflow: hidden; /* 隱藏超出容器的內容 */
+  text-overflow: ellipsis; /* 使用省略號表示被截斷的文字 */
+  font-size: 1.3rem; /* 調整字體大小 */
 }
 
 /* 搜尋結果摘要 */
@@ -75,4 +99,28 @@
 .result-updated {
   margin-right: 10px;
   color: #333; /* 作者和更新時間顏色 */
+}
+
+/* 分頁樣式 */
+.pagination {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination button {
+  background-color: #ffffff; /* 按鈕背景顏色 */
+  border: 1px solid #ddd; /* 按鈕邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+  margin: 0 10px;
+}
+
+.pagination button:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
 }

--- a/frontend/src/styles/pages/TagPage.module.css
+++ b/frontend/src/styles/pages/TagPage.module.css
@@ -1,0 +1,123 @@
+/* 頁面整體樣式 */
+.tag_page {
+  padding: 20px;
+  background-color: #f4f4f9; /* 背景顏色 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: Arial, sans-serif; /* 字體 */
+  min-height: 100vh; /* 使頁面高度至少為視口高度 */
+}
+
+/* 標籤列表區域 */
+.tag_list {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px; /* 標籤之間的間距 */
+}
+
+/* 標籤按鈕樣式 */
+.tag_button {
+  background-color: #ffffff; /* 按鈕背景顏色 */
+  border: 1px solid #ddd; /* 按鈕邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.tag_button:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
+}
+
+/* 文章列表區域 */
+.article-list {
+  width: 80%; /* 調整寬度 */
+  max-width: 800px;
+  background-color: #ffffff; /* 背景 */
+  padding: 20px;
+  border-radius: 10px; /* 圓角效果 */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 陰影效果 */
+}
+
+/* 單個文章卡片 */
+.article-card {
+  background-color: #f8f8f8; /* 卡片背景顏色 */
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 8px; /* 卡片圓角 */
+  border: 1px solid #bbb; /* 卡片邊框 */
+  display: flex;
+  flex-direction: column; /* 使內容垂直排列 */
+  text-align: left;
+  color: #333; /* 文字顏色 */
+}
+
+/* 內容區域，包含標題、作者和更新時間 */
+.article-content {
+  display: flex;
+  flex-direction: row; /* 水平排列內容 */
+  align-items: center;
+  margin-bottom: 10px; /* 與內容文本的間距 */
+}
+
+/* 標題、作者和更新時間 */
+.article-title {
+  font-weight: bold;
+  margin-right: 10px;
+  color: #333; /* 標題顏色 */
+  flex: 1; /* 使標題占據可用空間 */
+  white-space: nowrap; /* 不換行 */
+  overflow: hidden; /* 隱藏超出容器的內容 */
+  text-overflow: ellipsis; /* 使用省略號表示被截斷的文字 */
+  font-size: 1.3rem; /* 調整字體大小，可以根據需要修改 */
+}
+
+.article-author,
+.article-updated,
+.article-tag {
+  margin-right: 10px;
+  color: #333; /* 作者、更新時間和標籤顏色 */
+}
+
+/* 文章摘要 */
+.article-excerpt {
+  color: #666; /* 內容顏色 */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2; /* 顯示兩行 */
+  line-height: 1.5; /* 行高，可根據需要調整 */
+}
+
+/* 分頁樣式 */
+.pagination {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination button {
+  background-color: #ffffff; /* 按鈕背景顏色 */
+  border: 1px solid #ddd; /* 按鈕邊框 */
+  padding: 10px 20px;
+  border-radius: 5px; /* 圓角效果 */
+  color: #333; /* 文字顏色 */
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+  margin: 0 10px;
+}
+
+.pagination button:hover {
+  background-color: #f0f0f0; /* 懸停時背景顏色 */
+  border-color: #ccc; /* 懸停時邊框顏色 */
+}
+
+.pagination span {
+  font-size: 1rem;
+}

--- a/src/main/java/com/example/blog/Controller/ArticleSearchController.java
+++ b/src/main/java/com/example/blog/Controller/ArticleSearchController.java
@@ -31,4 +31,11 @@ public class ArticleSearchController {
                                                   @RequestParam(defaultValue = "10") int size) {
         return service.searchArticles(keyword, page, size);
     }
+    // 根據標籤 ID 查詢文章，支持分頁
+    @GetMapping("/articlesByTag")
+    public Page<ArticleSearchView> getArticlesByTag(@RequestParam Long tagId,
+                                                    @RequestParam(defaultValue = "0") int page,
+                                                    @RequestParam(defaultValue = "10") int size) {
+        return service.findByTagId(tagId, page, size);
+    }
 }

--- a/src/main/java/com/example/blog/Model/ArticleSearchView.java
+++ b/src/main/java/com/example/blog/Model/ArticleSearchView.java
@@ -12,6 +12,7 @@ public class ArticleSearchView {
     private Long article_id;
     private String title;
     private String contentTEXT;
+    private Integer tag_id; // 使用包裝類型 Integer 來處理可能為 NULL 的值
     private String username;
     private String last_edited_at;
     
@@ -32,6 +33,12 @@ public class ArticleSearchView {
     }
     public void setContentTEXT(String contentTEXT) {
         this.contentTEXT = contentTEXT;
+    }
+    public Integer getTag_id() {
+        return tag_id;
+    }
+    public void setTag_id(Integer tag_id) {
+        this.tag_id = tag_id;
     }
     public String getUsername() {
         return username;

--- a/src/main/java/com/example/blog/Repository/ArticleSearchViewRepository.java
+++ b/src/main/java/com/example/blog/Repository/ArticleSearchViewRepository.java
@@ -18,4 +18,9 @@ public interface ArticleSearchViewRepository extends JpaRepository<ArticleSearch
     List<ArticleSearchView> searchArticles(@Param("keyword") String keyword);
 
     Page<ArticleSearchView> findByTitleContainingIgnoreCaseOrUsernameContainingIgnoreCase(String titleKeyword, String usernameKeyword, Pageable pageable);
+
+
+    // 添加根據標籤 ID 查詢的方法
+    @Query("SELECT a FROM ArticleSearchView a WHERE a.tag_id = :tagId")
+    Page<ArticleSearchView> findByTagId(@Param("tagId") Long tagId, Pageable pageable);
 }

--- a/src/main/java/com/example/blog/Service/ArticleSearchService.java
+++ b/src/main/java/com/example/blog/Service/ArticleSearchService.java
@@ -32,4 +32,10 @@ public class ArticleSearchService {
         Pageable pageable = PageRequest.of(page, size);
         return repository.findAll(pageable);
     }
+    
+    // 根據標籤 ID 查詢文章
+    public Page<ArticleSearchView> findByTagId(Long tagId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repository.findByTagId(tagId, pageable);
+    }
 }


### PR DESCRIPTION
文章上顯示標籤
透過點擊標籤列，顯示該標籤文章
搜尋後跳轉頁面保留搜尋參數
修改後端邏輯實現顯示標籤和點擊標籤搜尋文章
新增TagPage和其Css
在ArticlePage和SearchPage實現顯示標籤和點擊標籤搜尋文章功能並修改Css
修改分頁導航顯示小bug
